### PR TITLE
Default host for standalone JVMs to localhost.

### DIFF
--- a/etc/collectd.d/jvm-sun-hotspot.conf
+++ b/etc/collectd.d/jvm-sun-hotspot.conf
@@ -1,5 +1,6 @@
 # This is the monitoring configuration for standalone JVMs.
-# Replace JMX_HOST and JMX_PORT below with the values configured in your JVM deployment.
+# Look for JMX_HOST and JMX_PORT to adjust your configuration file.
+# Replace JMX_PORT below with the value configured in your JVM deployment.
 LoadPlugin java
 <Plugin "java">
     JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
@@ -112,7 +113,9 @@ LoadPlugin java
         </MBean>
 
         <Connection>
-            ServiceURL "service:jmx:rmi:///jndi/rmi://JMX_HOST:JMX_PORT/jmxrmi"
+            # When using non-standard JVM configurations, replace the below with
+            #ServiceURL "service:jmx:rmi:///jndi/rmi://JMX_HOST:JMX_PORT/jmxrmi"
+            ServiceURL "service:jmx:rmi:///jndi/rmi://localhost:JMX_PORT/jmxrmi"
             InstancePrefix "jvm"
 
             Collect "jvm_localhost_Threading"

--- a/templates/jvm-sun-hotspot.conf.jinja
+++ b/templates/jvm-sun-hotspot.conf.jinja
@@ -15,9 +15,10 @@ limitations under the License.
 #}
 {% extends "jmx-metrics-base.jinja" %}
 {% block header_comment %}
-# This is the monitoring configuration for standalone JVMs.
-# Replace {% block jmx_host_alt_name %}JMX_HOST{% endblock %} and {% block jmx_port_alt_name %}JMX_PORT{% endblock %} below with the values configured in your JVM deployment.
+{{ super() -}}
+# Replace {{ self.jmx_port_alt_name() }} below with the value configured in your JVM deployment.
 {% endblock header_comment %}
 {% block service %}JVM{% endblock %}
+{% block jmx_port %}{{ self.jmx_port_alt_name() }}{% endblock %}
 {% block non_java_metrics %}{% endblock %}
 {% block service_chains %}{% endblock %}


### PR DESCRIPTION
I'm assuming that the common case would be to monitor a local JVM.