### PR TITLE
Memcached plugin supports instances

### DIFF
--- a/etc/collectd.d/memcached.conf
+++ b/etc/collectd.d/memcached.conf
@@ -2,9 +2,11 @@
 # Look for MEMCACHED_HOST and MEMCACHED_PORT to adjust your configuration file.
 LoadPlugin memcached
 <Plugin "memcached">
-    # When using non-standard memcached configurations, replace the below with
-    #Host "MEMCACHED_HOST"
-    #Port "MEMCACHED_PORT"
-    Host "localhost"
-    Port "11211"
+    <Instance "localhost">
+        # When using non-standard memcached configurations, replace the below with
+        #Host "MEMCACHED_HOST"
+        #Port "MEMCACHED_PORT"
+        Host "localhost"
+        Port "11211"
+    </Instance>
 </Plugin>


### PR DESCRIPTION
The memcached plugin supports having instance blocks with custom configuration for each instance. See https://github.com/Stackdriver/collectd/blob/stackdriver-agent-5.5.2/src/memcached.c#L653