### PR TITLE
More Cassandra mappings

### DIFF
--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -602,18 +602,6 @@ LoadPlugin java
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-1m"
-                Table false
-                Attribute "OneMinuteRate"
-            </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "client_request_read-latency-15m"
-                Table false
-                Attribute "FifteenMinuteRate"
-            </Value>
-            <Value>
-                Type "gauge"
                 InstancePrefix "client_request_read-latency-max"
                 Table false
                 Attribute "Max"
@@ -639,18 +627,6 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_ClientRequest_Write-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
-            <Value>
-                Type "gauge"
-                InstancePrefix "client_request_write-latency-1m"
-                Table false
-                Attribute "OneMinuteRate"
-            </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "client_request_write-latency-15m"
-                Table false
-                Attribute "FifteenMinuteRate"
-            </Value>
             <Value>
                 Type "gauge"
                 InstancePrefix "client_request_write-latency-max"
@@ -702,12 +678,6 @@ LoadPlugin java
                 Table false
                 Attribute "Count"
             </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "dropped_message_mutation-dropped-1m"
-                Table false
-                Attribute "OneMinuteRate"
-            </Value>
         </MBean>
         <MBean "cassandra_DroppedMessage_READ-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
@@ -716,12 +686,6 @@ LoadPlugin java
                 InstancePrefix "dropped_message_read-dropped-count"
                 Table false
                 Attribute "Count"
-            </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "dropped_message_read-dropped-1m"
-                Table false
-                Attribute "OneMinuteRate"
             </Value>
         </MBean>
         <MBean "cassandra_FileCache-Hits">

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -627,9 +627,9 @@ LoadPlugin java
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "90p"
+                InstancePrefix "95p"
                 Table false
-                Attribute "90thPercentile"
+                Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
@@ -667,9 +667,9 @@ LoadPlugin java
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "90p"
+                InstancePrefix "95p"
                 Table false
-                Attribute "90thPercentile"
+                Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -600,80 +600,78 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_ClientRequest_Read-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
-            InstancePrefix "client_request_read-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "client_request_read-latency-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "15m"
+                InstancePrefix "client_request_read-latency-15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "max"
+                InstancePrefix "client_request_read-latency-max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "99p"
+                InstancePrefix "client_request_read-latency-99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "95p"
+                InstancePrefix "client_request_read-latency-95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "50p"
+                InstancePrefix "client_request_read-latency-50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
         </MBean>
         <MBean "cassandra_ClientRequest_Write-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
-            InstancePrefix "client_request_write-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "client_request_write-latency-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "15m"
+                InstancePrefix "client_request_write-latency-15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "max"
+                InstancePrefix "client_request_write-latency-max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "99p"
+                InstancePrefix "client_request_write-latency-99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "95p"
+                InstancePrefix "client_request_write-latency-95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "50p"
+                InstancePrefix "client_request_write-latency-50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
@@ -698,32 +696,30 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_DroppedMessage_MUTATION-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
-            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "count"
+                InstancePrefix "dropped_message_mutation-dropped-count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "dropped_message_mutation-dropped-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
         </MBean>
         <MBean "cassandra_DroppedMessage_READ-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
-            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "count"
+                InstancePrefix "dropped_message_read-dropped-count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "dropped_message_read-dropped-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -593,7 +593,7 @@ LoadPlugin java
             ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=Hits"
             <Value>
                 Type "gauge"
-                InstancePrefix "cache_key_cache-hit_rate"
+                InstancePrefix "cache_key_cache-hits"
                 Table false
                 Attribute "Value"
             </Value>

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -600,78 +600,80 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_ClientRequest_Read-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
+            InstancePrefix "client_request_read-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-15m"
+                InstancePrefix "15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-max"
+                InstancePrefix "max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-99p"
+                InstancePrefix "99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-95p"
+                InstancePrefix "95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-50p"
+                InstancePrefix "50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
         </MBean>
         <MBean "cassandra_ClientRequest_Write-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
+            InstancePrefix "client_request_write-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-15m"
+                InstancePrefix "15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-max"
+                InstancePrefix "max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-99p"
+                InstancePrefix "99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-95p"
+                InstancePrefix "95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-50p"
+                InstancePrefix "50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
@@ -696,30 +698,32 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_DroppedMessage_MUTATION-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
+            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "dropped_message_mutation-dropped-count"
+                InstancePrefix "count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "dropped_message_mutation-dropped-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
         </MBean>
         <MBean "cassandra_DroppedMessage_READ-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
+            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "dropped_message_read-dropped-count"
+                InstancePrefix "count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "dropped_message_read-dropped-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -589,6 +589,154 @@ LoadPlugin java
                 Attribute "Value"
             </Value>
         </MBean>
+        <MBean "cassandra_Cache_KeyCache-HitRate">
+            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=HitRate"
+            <Value>
+                Type "gauge"
+                InstancePrefix "cache_key_cache-hit_rate"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ClientRequest_Read-Latency">
+            ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
+	    InstancePrefix "client_request_read-latency-"
+            <Value>
+                Type "gauge"
+                InstancePrefix "1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "15m"
+                Table false
+                Attribute "FifteenMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "max"
+                Table false
+                Attribute "Max"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "99p"
+                Table false
+                Attribute "99thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "90p"
+                Table false
+                Attribute "90thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "50p"
+                Table false
+                Attribute "50thPercentile"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ClientRequest_Write-Latency">
+            ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
+	    InstancePrefix "client_request_write-latency-"
+            <Value>
+                Type "gauge"
+                InstancePrefix "1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "15m"
+                Table false
+                Attribute "FifteenMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "max"
+                Table false
+                Attribute "Max"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "99p"
+                Table false
+                Attribute "99thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "90p"
+                Table false
+                Attribute "90thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "50p"
+                Table false
+                Attribute "50thPercentile"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ColumnFamily-MaxRowSize">
+            ObjectName "org.apache.cassandra.metrics:type=ColumnFamily,name=MaxRowSize"
+            <Value>
+                Type "gauge"
+                InstancePrefix "column_family-max_row_size"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ColumnFamily-CompressionRatio">
+            ObjectName "org.apache.cassandra.metrics:type=ColumnFamily,name=CompressionRatio"
+            <Value>
+                Type "gauge"
+                InstancePrefix "column_family-compression_ratio"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_DroppedMessage_MUTATION-Dropped">
+            ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
+            InstancePrefix "dropped_message_mutation-dropped-"
+            <Value>
+                Type "counter"
+                InstancePrefix "count"
+                Table false
+                Attribute "Count"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+        </MBean>
+        <MBean "cassandra_DroppedMessage_READ-Dropped">
+            ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
+            InstancePrefix "dropped_message_read-dropped-"
+            <Value>
+                Type "counter"
+                InstancePrefix "count"
+                Table false
+                Attribute "Count"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+        </MBean>
+        <MBean "cassandra_FileCache-Hits">
+            ObjectName "org.apache.cassandra.metrics:type=FileCache,name=Hits"
+            <Value>
+                Type "counter"
+                InstancePrefix "file_cache-hits"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
 
 
         <Connection>
@@ -660,6 +808,14 @@ LoadPlugin java
             Collect "cassandra_internal_StreamStage-blocked"
             Collect "cassandra_internal_StreamStage-pending"
             Collect "cassandra_internal_StreamStage-completed"
+            Collect "cassandra_Cache_KeyCache-HitRate"
+            Collect "cassandra_ClientRequest_Read-Latency"
+            Collect "cassandra_ClientRequest_Write-Latency"
+            Collect "cassandra_ColumnFamily-MaxRowSize"
+            Collect "cassandra_ColumnFamily-CompressionRatio"
+            Collect "cassandra_DroppedMessage_MUTATION-Dropped"
+            Collect "cassandra_DroppedMessage_READ-Dropped"
+            Collect "cassandra_FileCache-Hits"
         </Connection>
 
 

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -612,7 +612,7 @@ LoadPlugin java
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
-            <Value>uuuuuoeauoeuoe
+            <Value>
                 Type "gauge"
                 InstancePrefix "client_request_read-latency-max"
                 Table false

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -600,80 +600,78 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_ClientRequest_Read-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
-	    InstancePrefix "client_request_read-latency-"
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "client_request_read-latency-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "15m"
+                InstancePrefix "client_request_read-latency-15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
-            <Value>
+            <Value>uuuuuoeauoeuoe
                 Type "gauge"
-                InstancePrefix "max"
+                InstancePrefix "client_request_read-latency-max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "99p"
+                InstancePrefix "client_request_read-latency-99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "95p"
+                InstancePrefix "client_request_read-latency-95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "50p"
+                InstancePrefix "client_request_read-latency-50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
         </MBean>
         <MBean "cassandra_ClientRequest_Write-Latency">
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
-	    InstancePrefix "client_request_write-latency-"
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "client_request_write-latency-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "15m"
+                InstancePrefix "client_request_write-latency-15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "max"
+                InstancePrefix "client_request_write-latency-max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "99p"
+                InstancePrefix "client_request_write-latency-99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "95p"
+                InstancePrefix "client_request_write-latency-95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "50p"
+                InstancePrefix "client_request_write-latency-50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
@@ -698,32 +696,30 @@ LoadPlugin java
         </MBean>
         <MBean "cassandra_DroppedMessage_MUTATION-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
-            InstancePrefix "dropped_message_mutation-dropped-"
             <Value>
                 Type "counter"
-                InstancePrefix "count"
+                InstancePrefix "dropped_message_mutation-dropped-count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "dropped_message_mutation-dropped-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
         </MBean>
         <MBean "cassandra_DroppedMessage_READ-Dropped">
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
-            InstancePrefix "dropped_message_read-dropped-"
             <Value>
                 Type "counter"
-                InstancePrefix "count"
+                InstancePrefix "dropped_message_read-dropped-count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "dropped_message_read-dropped-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -589,8 +589,8 @@ LoadPlugin java
                 Attribute "Value"
             </Value>
         </MBean>
-        <MBean "cassandra_Cache_KeyCache-HitRate">
-            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=HitRate"
+        <MBean "cassandra_Cache_KeyCache-Hits">
+            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=Hits"
             <Value>
                 Type "gauge"
                 InstancePrefix "cache_key_cache-hit_rate"
@@ -804,7 +804,7 @@ LoadPlugin java
             Collect "cassandra_internal_StreamStage-blocked"
             Collect "cassandra_internal_StreamStage-pending"
             Collect "cassandra_internal_StreamStage-completed"
-            Collect "cassandra_Cache_KeyCache-HitRate"
+            Collect "cassandra_Cache_KeyCache-Hits"
             Collect "cassandra_ClientRequest_Read-Latency"
             Collect "cassandra_ClientRequest_Write-Latency"
             Collect "cassandra_ColumnFamily-MaxRowSize"

--- a/etc/collectd.d/cassandra-22.conf
+++ b/etc/collectd.d/cassandra-22.conf
@@ -688,15 +688,6 @@ LoadPlugin java
                 Attribute "Count"
             </Value>
         </MBean>
-        <MBean "cassandra_FileCache-Hits">
-            ObjectName "org.apache.cassandra.metrics:type=FileCache,name=Hits"
-            <Value>
-                Type "counter"
-                InstancePrefix "file_cache-hits"
-                Table false
-                Attribute "Count"
-            </Value>
-        </MBean>
 
 
         <Connection>
@@ -775,7 +766,6 @@ LoadPlugin java
             Collect "cassandra_ColumnFamily-CompressionRatio"
             Collect "cassandra_DroppedMessage_MUTATION-Dropped"
             Collect "cassandra_DroppedMessage_READ-Dropped"
-            Collect "cassandra_FileCache-Hits"
         </Connection>
 
 

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -615,18 +615,6 @@ limitations under the License.
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-1m"
-                Table false
-                Attribute "OneMinuteRate"
-            </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "client_request_read-latency-15m"
-                Table false
-                Attribute "FifteenMinuteRate"
-            </Value>
-            <Value>
-                Type "gauge"
                 InstancePrefix "client_request_read-latency-max"
                 Table false
                 Attribute "Max"
@@ -652,18 +640,6 @@ limitations under the License.
         {%- endcall %}
         {% call mbean("cassandra_ClientRequest_Write-Latency", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
-            <Value>
-                Type "gauge"
-                InstancePrefix "client_request_write-latency-1m"
-                Table false
-                Attribute "OneMinuteRate"
-            </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "client_request_write-latency-15m"
-                Table false
-                Attribute "FifteenMinuteRate"
-            </Value>
             <Value>
                 Type "gauge"
                 InstancePrefix "client_request_write-latency-max"
@@ -715,12 +691,6 @@ limitations under the License.
                 Table false
                 Attribute "Count"
             </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "dropped_message_mutation-dropped-1m"
-                Table false
-                Attribute "OneMinuteRate"
-            </Value>
         {%- endcall %}
         {% call mbean("cassandra_DroppedMessage_READ-Dropped", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
@@ -729,12 +699,6 @@ limitations under the License.
                 InstancePrefix "dropped_message_read-dropped-count"
                 Table false
                 Attribute "Count"
-            </Value>
-            <Value>
-                Type "gauge"
-                InstancePrefix "dropped_message_read-dropped-1m"
-                Table false
-                Attribute "OneMinuteRate"
             </Value>
         {%- endcall %}
         {% call mbean("cassandra_FileCache-Hits", mbeans) -%}

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -602,4 +602,148 @@ limitations under the License.
                 Attribute "Value"
             </Value>
         {%- endcall %}
+        {% call mbean("cassandra_Cache_KeyCache-HitRate", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=HitRate"
+            <Value>
+                Type "gauge"
+                InstancePrefix "cache_key_cache-hit_rate"
+                Table false
+                Attribute "Value"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_ClientRequest_Read-Latency", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-15m"
+                Table false
+                Attribute "FifteenMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-max"
+                Table false
+                Attribute "Max"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-99p"
+                Table false
+                Attribute "99thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-95p"
+                Table false
+                Attribute "95thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-50p"
+                Table false
+                Attribute "50thPercentile"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_ClientRequest_Write-Latency", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-15m"
+                Table false
+                Attribute "FifteenMinuteRate"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-max"
+                Table false
+                Attribute "Max"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-99p"
+                Table false
+                Attribute "99thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-95p"
+                Table false
+                Attribute "95thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-50p"
+                Table false
+                Attribute "50thPercentile"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_ColumnFamily-MaxRowSize", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=ColumnFamily,name=MaxRowSize"
+            <Value>
+                Type "gauge"
+                InstancePrefix "column_family-max_row_size"
+                Table false
+                Attribute "Value"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_ColumnFamily-CompressionRatio", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=ColumnFamily,name=CompressionRatio"
+            <Value>
+                Type "gauge"
+                InstancePrefix "column_family-compression_ratio"
+                Table false
+                Attribute "Value"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_DroppedMessage_MUTATION-Dropped", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
+            <Value>
+                Type "counter"
+                InstancePrefix "dropped_message_mutation-dropped-count"
+                Table false
+                Attribute "Count"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "dropped_message_mutation-dropped-1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_DroppedMessage_READ-Dropped", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
+            <Value>
+                Type "counter"
+                InstancePrefix "dropped_message_read-dropped-count"
+                Table false
+                Attribute "Count"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "dropped_message_read-dropped-1m"
+                Table false
+                Attribute "OneMinuteRate"
+            </Value>
+        {%- endcall %}
+        {% call mbean("cassandra_FileCache-Hits", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=FileCache,name=Hits"
+            <Value>
+                Type "counter"
+                InstancePrefix "file_cache-hits"
+                Table false
+                Attribute "Count"
+            </Value>
+        {%- endcall %}
 {% endblock mbean_list %}

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -613,80 +613,78 @@ limitations under the License.
         {%- endcall %}
         {% call mbean("cassandra_ClientRequest_Read-Latency", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
-            InstancePrefix "client_request_read-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "client_request_read-latency-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "15m"
+                InstancePrefix "client_request_read-latency-15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "max"
+                InstancePrefix "client_request_read-latency-max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "99p"
+                InstancePrefix "client_request_read-latency-99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "95p"
+                InstancePrefix "client_request_read-latency-95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "50p"
+                InstancePrefix "client_request_read-latency-50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
         {%- endcall %}
         {% call mbean("cassandra_ClientRequest_Write-Latency", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
-            InstancePrefix "client_request_write-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "client_request_write-latency-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "15m"
+                InstancePrefix "client_request_write-latency-15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "max"
+                InstancePrefix "client_request_write-latency-max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "99p"
+                InstancePrefix "client_request_write-latency-99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "95p"
+                InstancePrefix "client_request_write-latency-95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "50p"
+                InstancePrefix "client_request_write-latency-50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
@@ -711,32 +709,30 @@ limitations under the License.
         {%- endcall %}
         {% call mbean("cassandra_DroppedMessage_MUTATION-Dropped", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
-            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "count"
+                InstancePrefix "dropped_message_mutation-dropped-count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "dropped_message_mutation-dropped-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
         {%- endcall %}
         {% call mbean("cassandra_DroppedMessage_READ-Dropped", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
-            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "count"
+                InstancePrefix "dropped_message_read-dropped-count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "1m"
+                InstancePrefix "dropped_message_read-dropped-1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -701,13 +701,4 @@ limitations under the License.
                 Attribute "Count"
             </Value>
         {%- endcall %}
-        {% call mbean("cassandra_FileCache-Hits", mbeans) -%}
-            ObjectName "org.apache.cassandra.metrics:type=FileCache,name=Hits"
-            <Value>
-                Type "counter"
-                InstancePrefix "file_cache-hits"
-                Table false
-                Attribute "Count"
-            </Value>
-        {%- endcall %}
 {% endblock mbean_list %}

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -613,78 +613,80 @@ limitations under the License.
         {%- endcall %}
         {% call mbean("cassandra_ClientRequest_Read-Latency", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
+            InstancePrefix "client_request_read-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-15m"
+                InstancePrefix "15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-max"
+                InstancePrefix "max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-99p"
+                InstancePrefix "99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-95p"
+                InstancePrefix "95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_read-latency-50p"
+                InstancePrefix "50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
         {%- endcall %}
         {% call mbean("cassandra_ClientRequest_Write-Latency", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
+            InstancePrefix "client_request_write-latency"
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-15m"
+                InstancePrefix "15m"
                 Table false
                 Attribute "FifteenMinuteRate"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-max"
+                InstancePrefix "max"
                 Table false
                 Attribute "Max"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-99p"
+                InstancePrefix "99p"
                 Table false
                 Attribute "99thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-95p"
+                InstancePrefix "95p"
                 Table false
                 Attribute "95thPercentile"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "client_request_write-latency-50p"
+                InstancePrefix "50p"
                 Table false
                 Attribute "50thPercentile"
             </Value>
@@ -709,30 +711,32 @@ limitations under the License.
         {%- endcall %}
         {% call mbean("cassandra_DroppedMessage_MUTATION-Dropped", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
+            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "dropped_message_mutation-dropped-count"
+                InstancePrefix "count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "dropped_message_mutation-dropped-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>
         {%- endcall %}
         {% call mbean("cassandra_DroppedMessage_READ-Dropped", mbeans) -%}
             ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
+            InstancePrefix "dropped_message_mutation-dropped"
             <Value>
                 Type "counter"
-                InstancePrefix "dropped_message_read-dropped-count"
+                InstancePrefix "count"
                 Table false
                 Attribute "Count"
             </Value>
             <Value>
                 Type "gauge"
-                InstancePrefix "dropped_message_read-dropped-1m"
+                InstancePrefix "1m"
                 Table false
                 Attribute "OneMinuteRate"
             </Value>

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -602,8 +602,8 @@ limitations under the License.
                 Attribute "Value"
             </Value>
         {%- endcall %}
-        {% call mbean("cassandra_Cache_KeyCache-HitRate", mbeans) -%}
-            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=HitRate"
+        {% call mbean("cassandra_Cache_KeyCache-Hits", mbeans) -%}
+            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=Hits"
             <Value>
                 Type "gauge"
                 InstancePrefix "cache_key_cache-hit_rate"

--- a/templates/cassandra-22.conf.jinja
+++ b/templates/cassandra-22.conf.jinja
@@ -606,7 +606,7 @@ limitations under the License.
             ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=Hits"
             <Value>
                 Type "gauge"
-                InstancePrefix "cache_key_cache-hit_rate"
+                InstancePrefix "cache_key_cache-hits"
                 Table false
                 Attribute "Value"
             </Value>


### PR DESCRIPTION
I tested this with Cassandra 3.11.0. It finds all beans except for org.apache.cassandra.metrics:type=FileCache,name=Hits. A customer requested it by name and I've seen references to it on the internet, so I assume it's either enabled via configuration or in some older version of Cassandra.