### PR TITLE
Added sample StatsD configuration template

### DIFF
--- a/templates/statsd.conf.jinja
+++ b/templates/statsd.conf.jinja
@@ -1,0 +1,47 @@
+{#
+Copyright 2017 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+# This is the monitoring configuration for StatsD.
+# Look for STATSD_HOST and STATSD_PORT to adjust your configuration file.
+LoadPlugin statsd
+
+<Plugin statsd>
+  # When using non-standard StatsD configurations, replace the below with
+  #Host "STATSD_HOST"
+  #Port "STATSD_PORT"
+  Host "127.0.0.1"
+  Port "8125"
+  DeleteSets true
+  TimerPercentile 50.0
+  TimerPercentile 95.0
+  TimerLower true
+  TimerUpper true
+  TimerSum true
+  TimerCount true
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+
+PreCacheChain "PreCache"
+<Chain "PreCache">
+  <Rule "rewrite_statsd">
+    <Match regex>
+      Plugin "^statsd$"
+    </Match>
+    <Target "set">
+      MetaData "stackdriver_metric_type" "custom.googleapis.com/statsd/%{type}"
+      MetaData "label:metric" "%{type_instance}"
+    </Target>
+  </Rule>
+</Chain>


### PR DESCRIPTION
Documentation will be soon available at https://cloud.google.com/monitoring/agent/plugins/statsd