### PR TITLE
Restore Elasticsearch cluster health metrics.

### DIFF
--- a/etc/collectd.d/elasticsearch-1.conf
+++ b/etc/collectd.d/elasticsearch-1.conf
@@ -107,6 +107,34 @@ LoadPlugin curl_json
             Type "gauge"
         </Key>
     </URL>
+
+    # When using non-standard Elasticsearch configurations, replace the below with
+    #<URL "http://ELASTICSEARCH_HOST:ELASTICSEARCH_PORT/_cluster/health/">
+    <URL "http://localhost:9200/_cluster/health/">
+        Instance "elasticsearch"
+
+        <Key "number_of_nodes">
+            Type "gauge"
+        </Key>
+        <Key "number_of_data_nodes">
+            Type "gauge"
+        </Key>
+        <Key "active_primary_shards">
+            Type "gauge"
+        </Key>
+        <Key "active_shards">
+            Type "gauge"
+        </Key>
+        <Key "relocating_shards">
+            Type "gauge"
+        </Key>
+        <Key "initializing_shards">
+            Type "gauge"
+        </Key>
+        <Key "unassigned_shards">
+            Type "gauge"
+        </Key>
+    </URL>
 </Plugin>
 
 LoadPlugin match_regex

--- a/etc/collectd.d/elasticsearch.conf
+++ b/etc/collectd.d/elasticsearch.conf
@@ -107,6 +107,34 @@ LoadPlugin curl_json
             Type "gauge"
         </Key>
     </URL>
+
+    # When using non-standard Elasticsearch configurations, replace the below with
+    #<URL "http://ELASTICSEARCH_HOST:ELASTICSEARCH_PORT/_cluster/health/">
+    <URL "http://localhost:9200/_cluster/health/">
+        Instance "elasticsearch"
+
+        <Key "number_of_nodes">
+            Type "gauge"
+        </Key>
+        <Key "number_of_data_nodes">
+            Type "gauge"
+        </Key>
+        <Key "active_primary_shards">
+            Type "gauge"
+        </Key>
+        <Key "active_shards">
+            Type "gauge"
+        </Key>
+        <Key "relocating_shards">
+            Type "gauge"
+        </Key>
+        <Key "initializing_shards">
+            Type "gauge"
+        </Key>
+        <Key "unassigned_shards">
+            Type "gauge"
+        </Key>
+    </URL>
 </Plugin>
 
 LoadPlugin match_regex

--- a/templates/curl_json-metrics-base.jinja
+++ b/templates/curl_json-metrics-base.jinja
@@ -18,6 +18,19 @@ limitations under the License.
             Type "{{ type }}"
         </Key>
 {% endmacro %}
+{% macro url(url_suffix) %}
+    {% block service_url_start scoped %}
+    # When using non-standard {% block service %}{% endblock %} configurations, replace the below with
+    #<URL "http://{{ self.host_alt_name() }}:{{ self.port_alt_name() }}/{{ url_suffix }}">
+    <URL "http://{% block host %}localhost{% endblock %}:{% block port %}{% endblock %}/{{ url_suffix }}">
+    {% endblock service_url_start %}
+        Instance "{% block plugin_instance %}{{ self.service()|lower }}{% endblock %}"
+
+{{ caller() -}}
+    {% block service_url_end %}
+    </URL>
+    {% endblock service_url_end %}
+{% endmacro %}
 {% block header_comment %}
 # This is the monitoring configuration for {% block target %}{% endblock %}.
 # Look for {% block host_port_variables %}{% block host_alt_name %}{% block host_port_prefix %}{% endblock %}_HOST{% endblock %} and {% block port_alt_name %}{{ self.host_port_prefix() }}_PORT{% endblock %}{% endblock host_port_variables %} to adjust your configuration file.
@@ -25,18 +38,10 @@ limitations under the License.
 LoadPlugin curl_json
 <Plugin "curl_json">
     {% block service_url %}
-    {% block service_url_start %}
-    # When using non-standard {% block service %}{% endblock %} configurations, replace the below with
-    #<URL "http://{{ self.host_alt_name() }}:{{ self.port_alt_name() }}/{% block url_suffix %}{% endblock %}">
-    <URL "http://{% block host %}localhost{% endblock %}:{% block port %}{% endblock %}/{{ self.url_suffix() }}">
-    {% endblock service_url_start %}
-        Instance "{% block plugin_instance %}{{ self.service()|lower }}{% endblock %}"
-
-        {% block key_list %}
-        {% endblock %}
-    {% block service_url_end %}
-    </URL>
-    {% endblock service_url_end %}
+    {% set url_suffix %}{% block url_suffix %}{% endblock %}{% endset %}
+    {% call url(url_suffix) %}
+{% block key_list %}{% endblock %}
+    {% endcall %}
     {% endblock service_url %}
 </Plugin>
 

--- a/templates/elasticsearch-1.conf.jinja
+++ b/templates/elasticsearch-1.conf.jinja
@@ -19,7 +19,9 @@ limitations under the License.
 {% block host_port_prefix %}ELASTICSEARCH{% endblock %}
 {% block port %}9200{% endblock %}
 {% block url_suffix %}_nodes/_local/stats/{% endblock %}
-{% block key_list %}
+{% block service_url %}
+    {% set url_suffix %}{{ self.url_suffix() }}{% endset %}
+    {% call url(url_suffix) %}
         <Key "nodes/*/indices/docs/count">
             Type "gauge"
         </Key>
@@ -119,4 +121,29 @@ limitations under the License.
         <Key "nodes/*/http/current_open">
             Type "gauge"
         </Key>
-{% endblock key_list %}
+    {% endcall %}
+
+    {% call url("_cluster/health/") %}
+        <Key "number_of_nodes">
+            Type "gauge"
+        </Key>
+        <Key "number_of_data_nodes">
+            Type "gauge"
+        </Key>
+        <Key "active_primary_shards">
+            Type "gauge"
+        </Key>
+        <Key "active_shards">
+            Type "gauge"
+        </Key>
+        <Key "relocating_shards">
+            Type "gauge"
+        </Key>
+        <Key "initializing_shards">
+            Type "gauge"
+        </Key>
+        <Key "unassigned_shards">
+            Type "gauge"
+        </Key>
+    {% endcall %}
+{% endblock %}


### PR DESCRIPTION
This fixes a long-standing error in transcription. Original config [here](https://web.archive.org/web/20151002025444/http://support.stackdriver.com/customer/en/portal/articles/1491778-elasticsearch-plugin).