### PR TITLE
Use local-stackdriver-agent.stackdriver.com:80, which works in common situations.

### DIFF
--- a/etc/collectd.d/apache.conf
+++ b/etc/collectd.d/apache.conf
@@ -6,6 +6,6 @@ LoadPlugin apache
     <Instance "localhost">
         # When using non-standard Apache configurations, replace the below with
         #URL "http://APACHE_HOST:APACHE_PORT/server-status?auto"
-        URL "http://localhost:80/server-status?auto"
+        URL "http://local-stackdriver-agent.stackdriver.com:80/server-status?auto"
     </Instance>
 </Plugin>

--- a/templates/apache.conf.jinja
+++ b/templates/apache.conf.jinja
@@ -21,6 +21,6 @@ LoadPlugin apache
     <Instance "localhost">
         # When using non-standard Apache configurations, replace the below with
         #URL "http://APACHE_HOST:APACHE_PORT/server-status?auto"
-        URL "http://localhost:80/server-status?auto"
+        URL "http://local-stackdriver-agent.stackdriver.com:80/server-status?auto"
     </Instance>
 </Plugin>


### PR DESCRIPTION
This matches our sample [/etc/httpd/conf.d/status.conf](https://github.com/Stackdriver/stackdriver-agent-service-configs/blob/master/etc/httpd/conf.d/status.conf). This also matches the [nginx config](https://github.com/Stackdriver/stackdriver-agent-service-configs/blob/master/etc/collectd.d/nginx.conf).